### PR TITLE
Add router basepath for GitHub Pages and deployed URL to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 messing around with claude code while I am (allegedly) on vacation.
 
+**Deployed at:** http://emilyserven.net/claude-code-experiment/
+
 # The Stack
 
 This template exists because I don't really like fullstack frameworks.

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -10,6 +10,7 @@ import { ThemeProvider } from "@/context/ThemeProvider.tsx";
 
 const router = createRouter({
   routeTree,
+  basepath: import.meta.env.BASE_URL,
 });
 
 declare module "@tanstack/react-router" {


### PR DESCRIPTION
Set TanStack Router basepath to import.meta.env.BASE_URL so routing
works correctly under the /claude-code-experiment/ subpath on GitHub
Pages. Added the deployed URL to the README.

https://claude.ai/code/session_01HgmVPvSYWwo5T6ZUEohxRd