### PR TITLE
Add CI workflow and knip script for unused code reporting

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,45 @@
+name: CI
+
+on:
+  push:
+    branches: ["*"]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Configure npm registry for private packages
+        run: |
+          echo "@emilyeserven:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Test
+        run: pnpm test
+
+      - name: Build
+        run: pnpm build
+
+      - name: Report unused code with knip
+        run: pnpm knip

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "dev": "concurrently -n \"models,server,ui\" -c \"yellow,blue,green\" \"pnpm --filter=@cc-experiments/types --stream run dev\" \"pnpm --filter=@cc-experiments/middleware --stream run dev\" \"pnpm --filter=@cc-experiments/client --stream run dev\"",
     "lint": "eslint .",
     "lint:fix": "eslint .. --fix",
+    "knip": "knip",
     "storybook": "pnpm --filter=@cc-experiments/client run storybook",
     "prepare": "husky"
   },


### PR DESCRIPTION
Add a GitHub Actions CI workflow that runs on all branch pushes,
executing lint, test, build, and knip steps sequentially. Add a
root-level knip script to package.json to enable running the
existing knip configuration via pnpm.

https://claude.ai/code/session_01JmDJuLkmgPrb33YsznQ7Zx