### PR TITLE
Add empty state to TimerEntriesTable with usage instructions

### DIFF
--- a/packages/client/src/components/TimerEntriesTable.tsx
+++ b/packages/client/src/components/TimerEntriesTable.tsx
@@ -77,26 +77,48 @@ export function TimerEntriesTable({
           ))}
         </thead>
         <tbody>
-          {table.getRowModel().rows.map(row => (
-            <tr
-              key={row.id}
-              className={`
-                border-b
-                last:border-b-0
-                dark:border-gray-600
-              `}
-              data-testid="timer-entry"
-            >
-              {row.getVisibleCells().map(cell => (
+          {table.getRowModel().rows.length > 0
+            ? table.getRowModel().rows.map(row => (
+              <tr
+                key={row.id}
+                className={`
+                  border-b
+                  last:border-b-0
+                  dark:border-gray-600
+                `}
+                data-testid="timer-entry"
+              >
+                {row.getVisibleCells().map(cell => (
+                  <td
+                    key={cell.id}
+                    className="px-3 py-2"
+                  >
+                    {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  </td>
+                ))}
+              </tr>
+            ))
+            : (
+              <tr>
                 <td
-                  key={cell.id}
-                  className="px-3 py-2"
+                  colSpan={columns.length}
+                  className="px-3 py-6 text-center"
+                  data-testid="timer-entries-empty"
                 >
-                  {flexRender(cell.column.columnDef.cell, cell.getContext())}
+                  <p className="text-sm text-muted-foreground">
+                    {"No entries yet. Start the timer, type in the input field, and press "}
+                    <kbd className="rounded border px-1 py-0.5 text-xs">
+                      Enter
+                    </kbd>
+                    {" or click "}
+                    <strong>
+                      Submit
+                    </strong>
+                    {" to add an entry."}
+                  </p>
                 </td>
-              ))}
-            </tr>
-          ))}
+              </tr>
+            )}
         </tbody>
       </table>
     </div>

--- a/packages/client/src/routeTests/index.test.tsx
+++ b/packages/client/src/routeTests/index.test.tsx
@@ -31,10 +31,17 @@ describe("Index", () => {
     expect(input).toHaveValue("hello");
   });
 
+  it("shows empty state when there are no entries", () => {
+    render(<Index />);
+    expect(screen.getByTestId("timer-entries-empty")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("timer-entry")).toHaveLength(0);
+  });
+
   it("does not submit when input is empty", () => {
     render(<Index />);
     fireEvent.click(screen.getByTestId("timer-submit-button"));
-    expect(screen.queryByTestId("timer-entries-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("timer-entries-empty")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("timer-entry")).toHaveLength(0);
   });
 
   it("does not submit when input is only whitespace", () => {
@@ -46,7 +53,8 @@ describe("Index", () => {
       },
     });
     fireEvent.click(screen.getByTestId("timer-submit-button"));
-    expect(screen.queryByTestId("timer-entries-list")).not.toBeInTheDocument();
+    expect(screen.getByTestId("timer-entries-empty")).toBeInTheDocument();
+    expect(screen.queryAllByTestId("timer-entry")).toHaveLength(0);
   });
 
   it("submits an entry with text and current timestamp", () => {

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -60,9 +60,7 @@ export function Index() {
             Submit
           </Button>
         </div>
-        {entries.length > 0 && (
-          <TimerEntriesTable entries={entries} />
-        )}
+        <TimerEntriesTable entries={entries} />
       </div>
     </div>
   );


### PR DESCRIPTION
Show an instructional message when the table has no entries instead of
hiding the component entirely. The empty state tells users to start
the timer, type in the input field, and press Enter or click Submit.

https://claude.ai/code/session_0135KEtNEUJAP9joun1BreiW