### PR TITLE
Skip CI lint-fix commit when no files were changed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,13 +44,12 @@ jobs:
 
       - name: Commit lint fixes
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git reset -- .npmrc 2>/dev/null || true
-          if git diff --cached --quiet; then
+          if git diff --quiet; then
             echo "No lint fixes to commit"
           else
+            git config user.name "github-actions[bot]"
+            git config user.email "github-actions[bot]@users.noreply.github.com"
+            git add -u
             git commit -m "Ran lint fix in CI"
             git push
           fi


### PR DESCRIPTION
Replace `git add -A` + `git reset -- .npmrc` with `git diff --quiet`
check and `git add -u`. This ensures no commit is created when lint:fix
doesn't modify any tracked files, and avoids accidentally staging
untracked CI artifacts like .npmrc.

https://claude.ai/code/session_01FZVXsnyF92MesLBpT8pBLk