### PR TITLE
Skip husky hooks during CI lint-fix commit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,8 @@ jobs:
         run: pnpm run lint:fix
 
       - name: Commit lint fixes
+        env:
+          HUSKY: "0"
         run: |
           if git diff --quiet; then
             echo "No lint fixes to commit"


### PR DESCRIPTION
The CI "Commit lint fixes" step was failing because the husky
pre-commit hook ran lint-staged, which detected no additional changes
(since lint:fix already fixed everything) and rejected the commit as
empty. Setting HUSKY=0 disables hooks for this CI-only commit.

https://claude.ai/code/session_01J7pGGJvTAfwZWbnN8gPapZ