### PR TITLE
Install Playwright browsers in CI for Storybook browser tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Install Playwright browsers
+        run: pnpm --filter=@cc-experiments/client exec playwright install --with-deps chromium
+
       - name: Run lint fix
         run: pnpm run lint:fix
 


### PR DESCRIPTION
The CI test step has been failing since the workflow was created because
the Storybook vitest project requires Playwright Chromium to run browser
tests, but the CI workflow never installed Playwright browsers or their
system dependencies.

https://claude.ai/code/session_01JPELKnkGrbP6cxUTop7p4h