### PR TITLE
Split CI into parallel jobs and move e2e to merge queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,13 +5,15 @@ on:
     branches: ["*"]
   pull_request:
     branches: ["*"]
+  merge_group:
+    branches: [master, main]
 
 concurrency:
-  group: ci-${{ github.event.pull_request.head.ref || github.ref }}
+  group: ci-${{ github.head_ref || github.ref_name }}
   cancel-in-progress: true
 
 jobs:
-  ci:
+  lint:
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -39,15 +41,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Install Playwright browsers
-        run: |
-          (cd packages/client && npx playwright install --with-deps chromium)
-          npx playwright install chromium
-
       - name: Run lint fix
+        if: github.event_name != 'merge_group'
         run: pnpm run lint:fix
 
       - name: Commit lint fixes
+        if: github.event_name != 'merge_group'
         env:
           HUSKY: "0"
         run: |
@@ -114,22 +113,91 @@ jobs:
           echo "Lint failed with errors. See output above."
           exit 1
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Configure npm registry for private packages
+        run: |
+          echo "@emilyeserven:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: cd packages/client && npx playwright install --with-deps chromium
+
       - name: Test
         run: pnpm test
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Configure npm registry for private packages
+        run: |
+          echo "@emilyeserven:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Build
         run: pnpm build
 
-      - name: E2E tests
-        run: pnpm e2e
-
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
+  knip:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
         with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 14
+          ref: ${{ github.head_ref || github.ref_name }}
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Configure npm registry for private packages
+        run: |
+          echo "@emilyeserven:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
 
       - name: Report unused code with knip
         id: knip

--- a/.github/workflows/merge-checks.yml
+++ b/.github/workflows/merge-checks.yml
@@ -1,0 +1,47 @@
+name: Merge Checks
+
+on:
+  merge_group:
+    branches: [master, main]
+
+concurrency:
+  group: merge-checks-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: "pnpm"
+
+      - name: Configure npm registry for private packages
+        run: |
+          echo "@emilyeserven:registry=https://npm.pkg.github.com" >> .npmrc
+          echo "//npm.pkg.github.com/:_authToken=${{ secrets.GH_PACKAGES_TOKEN }}" >> .npmrc
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: E2E tests
+        run: pnpm e2e
+
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 14


### PR DESCRIPTION
- Split the monolithic CI job into separate lint, test, build, and
  knip jobs that run in parallel for faster feedback
- Remove e2e tests from CI pipeline (no longer runs on every push)
- Create merge-checks.yml with e2e tests triggered only by merge_group
  events, so e2e is required before merge but doesn't slow down PR pushes
- Add merge_group trigger to ci.yml so lint/test/build also run in the
  merge queue
- Fix concurrency group key to properly deduplicate push + pull_request
  events on the same branch

To enforce these as required merge checks, enable merge queue in repo
settings and add these required status checks: lint, test, build, e2e

https://claude.ai/code/session_017dQQ2vcZ2U1nPH1r6xu6v1