### PR TITLE
Add E2E job to CI, restricted to merge events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         run: pnpm --filter=@cc-experiments/middleware run test
 
       - name: Test client (unit)
-        run: pnpm --filter=@cc-experiments/client run test -- --project=unit-tests --run
+        run: pnpm --filter=@cc-experiments/client exec vitest run --project unit-tests
 
   storybook-tests:
     runs-on: ubuntu-latest
@@ -189,7 +189,7 @@ jobs:
         run: cd packages/client && npx playwright install-deps chromium
 
       - name: Test client (storybook)
-        run: pnpm --filter=@cc-experiments/client run test -- --project=storybook --run
+        run: pnpm --filter=@cc-experiments/client exec vitest run --project storybook
 
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Add Playwright E2E tests as a parallel CI job on all triggers, with results posted as a markdown PR comment (summary table with pass/fail/flaky/skipped counts and failed test details)
- Split the `test` job into `unit-tests` (middleware + client unit tests, no browser needed) and `storybook-tests` (client storybook tests via Playwright browser mode)
- Cache Playwright browser binaries across `storybook-tests` and `e2e` jobs using `actions/cache`, keyed by Playwright version — on cache hit, only OS-level system dependencies are installed
- Upload Playwright HTML report as a build artifact


https://claude.ai/code/session_01WVuL9xWpf3PLbv2ozLPJLY