### PR TITLE
Hide table checkboxes on mobile behind Enable Multiselect toggle (#42)

### DIFF
--- a/packages/client/src/components/SettingsPopover.stories.tsx
+++ b/packages/client/src/components/SettingsPopover.stories.tsx
@@ -2,9 +2,9 @@ import type { Meta, StoryObj } from "@storybook/react-vite";
 
 import { expect, userEvent, within } from "@storybook/test";
 
-import { ThemeProvider } from "@/context/ThemeProvider";
-
 import { SettingsPopover } from "./SettingsPopover";
+
+import { ThemeProvider } from "@/context/ThemeProvider";
 
 const meta = {
   component: SettingsPopover,

--- a/packages/client/src/components/Timer.test.tsx
+++ b/packages/client/src/components/Timer.test.tsx
@@ -1,9 +1,9 @@
 import { render, screen, fireEvent, act } from "@testing-library/react";
 import { beforeEach, afterEach, describe, expect, it, vi } from "vitest";
 
-import { formatTime } from "@/utils/formatTime";
-
 import { Timer } from "./Timer";
+
+import { formatTime } from "@/utils/formatTime";
 
 describe("formatTime", () => {
   it("formats zero milliseconds", () => {

--- a/packages/client/src/main.tsx
+++ b/packages/client/src/main.tsx
@@ -4,9 +4,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { createRouter, RouterProvider } from "@tanstack/react-router";
 import { createRoot } from "react-dom/client";
 
-import { ThemeProvider } from "@/context/ThemeProvider.tsx";
-
 import { routeTree } from "./routeTree.gen.ts";
+
+import { ThemeProvider } from "@/context/ThemeProvider.tsx";
 
 const router = createRouter({
   routeTree,


### PR DESCRIPTION
On mobile (<768px), the checkbox column is now hidden by default and
revealed only when the user clicks "Enable Multiselect". On desktop,
checkboxes continue to appear on row hover as before. Also fixes
pre-existing import order lint errors.

https://claude.ai/code/session_01Qc2UgBeibc4G3zpjgtE9Dh