### PR TITLE
Add edit entry button to row context menu (#51)

### DIFF
--- a/packages/client/src/components/TimerEntriesTable.stories.tsx
+++ b/packages/client/src/components/TimerEntriesTable.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 
-import { fn, within, expect, userEvent } from "@storybook/test";
+import { fn, within, expect, userEvent, waitFor } from "@storybook/test";
 
 import { TimerEntriesTable } from "./TimerEntriesTable";
 
@@ -23,6 +23,7 @@ const meta = {
   component: TimerEntriesTable,
   args: {
     entries: sampleEntries,
+    onEditEntry: fn(),
     onDeleteEntry: fn(),
     onDeleteEntries: fn(),
   },
@@ -220,5 +221,81 @@ export const DeleteConfirmed: Story = {
 
     // Selection should be cleared (delete button gone)
     await expect(canvas.queryByTestId("delete-selected-button")).not.toBeInTheDocument();
+  },
+};
+
+export const EditEntryOpensDialog: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    const triggers = canvas.getAllByTestId("entry-actions-trigger");
+
+    // Open the context menu for the first row
+    await userEvent.click(triggers[0]);
+
+    // Edit button should be visible
+    const body = within(document.body);
+    await expect(body.getByTestId("edit-entry-button")).toBeInTheDocument();
+
+    // Click edit
+    await userEvent.click(body.getByTestId("edit-entry-button"));
+
+    // Edit dialog should appear with pre-filled values
+    await expect(body.getByTestId("edit-entry-text-input")).toBeInTheDocument();
+    await expect(body.getByTestId("edit-entry-timestamp-input")).toBeInTheDocument();
+    await expect(body.getByTestId("edit-entry-text-input")).toHaveValue("First task");
+    await expect(body.getByTestId("edit-entry-timestamp-input")).toHaveValue("00:01:23.456");
+  },
+};
+
+export const EditEntrySave: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const triggers = canvas.getAllByTestId("entry-actions-trigger");
+
+    // Open context menu and click edit
+    await userEvent.click(triggers[0]);
+    const body = within(document.body);
+    await userEvent.click(body.getByTestId("edit-entry-button"));
+
+    // Clear and type new text
+    const textInput = body.getByTestId("edit-entry-text-input");
+    await userEvent.clear(textInput);
+    await userEvent.type(textInput, "Updated task");
+
+    // Click save
+    await userEvent.click(body.getByTestId("save-edit-button"));
+
+    // onEditEntry should have been called with updated values
+    await expect(args.onEditEntry).toHaveBeenCalledTimes(1);
+  },
+};
+
+export const EditEntryCancelled: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    const triggers = canvas.getAllByTestId("entry-actions-trigger");
+
+    // Open context menu and click edit
+    await userEvent.click(triggers[0]);
+    const body = within(document.body);
+    await userEvent.click(body.getByTestId("edit-entry-button"));
+
+    // Record call count before cancel
+    const callsBefore = (args.onEditEntry as ReturnType<typeof fn>).mock.calls.length;
+
+    // Click cancel
+    await userEvent.click(body.getByTestId("cancel-edit-button"));
+
+    // onEditEntry should not have been called again
+    await expect(args.onEditEntry).toHaveBeenCalledTimes(callsBefore);
+
+    // Dialog should be closed (wait for exit animation)
+    await waitFor(() => expect(body.queryByTestId("edit-entry-text-input")).not.toBeInTheDocument());
   },
 };

--- a/packages/client/src/components/TimerEntriesTable.tsx
+++ b/packages/client/src/components/TimerEntriesTable.tsx
@@ -8,7 +8,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, ListChecks, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, ListChecks, Pencil, Trash2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -22,6 +22,15 @@ import {
 } from "@/components/AlertDialog";
 import { Button } from "@/components/Button";
 import { Checkbox } from "@/components/Checkbox";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog";
+import { Input } from "@/components/Input";
 import { MarkdownExportDialog } from "@/components/MarkdownExportDialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover";
 import { useIsMobile } from "@/hooks/useIsMobile";
@@ -34,18 +43,21 @@ interface TimerEntry {
 
 interface TimerEntriesTableProps {
   entries: TimerEntry[];
+  onEditEntry: (index: number, entry: TimerEntry) => void;
   onDeleteEntry: (index: number) => void;
   onDeleteEntries: (indices: number[]) => void;
 }
 
 interface TableMeta {
+  onEditEntry: (index: number, entry: TimerEntry) => void;
   onDeleteEntry: (index: number) => void;
   isMobile: boolean;
 }
 
 function ActionsCell({
-  row, onDeleteEntry,
+  row, onEditEntry, onDeleteEntry,
 }: { row: Row<TimerEntry>;
+  onEditEntry: (index: number) => void;
   onDeleteEntry: (index: number) => void; }) {
   const [open, setOpen] = useState(false);
   return (
@@ -66,6 +78,19 @@ function ActionsCell({
         align="end"
         className="w-40 p-1"
       >
+        <Button
+          variant="ghost"
+          size="sm"
+          className="w-full justify-start"
+          onClick={() => {
+            setOpen(false);
+            onEditEntry(row.index);
+          }}
+          data-testid="edit-entry-button"
+        >
+          <Pencil className="mr-2 size-4" />
+          Edit Entry
+        </Button>
         <Button
           variant="ghost"
           size="sm"
@@ -161,11 +186,13 @@ const columns: ColumnDef<TimerEntry>[] = [
       table,
     }) => {
       const {
+        onEditEntry,
         onDeleteEntry,
       } = table.options.meta as TableMeta;
       return (
         <ActionsCell
           row={row}
+          onEditEntry={(index: number) => onEditEntry(index, row.original)}
           onDeleteEntry={onDeleteEntry}
         />
       );
@@ -175,6 +202,7 @@ const columns: ColumnDef<TimerEntry>[] = [
 
 export function TimerEntriesTable({
   entries,
+  onEditEntry,
   onDeleteEntry,
   onDeleteEntries,
 }: TimerEntriesTableProps) {
@@ -182,6 +210,10 @@ export function TimerEntriesTable({
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
   const [showMarkdownDialog, setShowMarkdownDialog] = useState(false);
+  const [editingEntry, setEditingEntry] = useState<{ index: number;
+    entry: TimerEntry; } | null>(null);
+  const [editText, setEditText] = useState("");
+  const [editTimestamp, setEditTimestamp] = useState("");
   const [multiselectEnabled, setMultiselectEnabled] = useState(false);
   const isMobile = useIsMobile();
 
@@ -216,6 +248,14 @@ export function TimerEntriesTable({
     getSortedRowModel: getSortedRowModel(),
     enableRowSelection: true,
     meta: {
+      onEditEntry: (index: number, entry: TimerEntry) => {
+        setEditingEntry({
+          index,
+          entry,
+        });
+        setEditText(entry.text);
+        setEditTimestamp(entry.timestamp);
+      },
       onDeleteEntry,
       isMobile,
     },
@@ -237,6 +277,15 @@ export function TimerEntriesTable({
       setRowSelection({});
     }
     setMultiselectEnabled(prev => !prev);
+  };
+
+  const handleEditSave = () => {
+    if (editingEntry === null || !editText.trim()) return;
+    onEditEntry(editingEntry.index, {
+      text: editText.trim(),
+      timestamp: editTimestamp,
+    });
+    setEditingEntry(null);
   };
 
   return (
@@ -418,6 +467,66 @@ export function TimerEntriesTable({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+
+      <Dialog
+        open={editingEntry !== null}
+        onOpenChange={open => !open && setEditingEntry(null)}
+      >
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Edit Entry</DialogTitle>
+            <DialogDescription>
+              Modify the text and timestamp for this entry.
+            </DialogDescription>
+          </DialogHeader>
+          <div className="grid gap-4 py-2">
+            <div className="grid gap-2">
+              <label
+                htmlFor="edit-entry-text"
+                className="text-sm font-medium"
+              >
+                Text
+              </label>
+              <Input
+                id="edit-entry-text"
+                value={editText}
+                onChange={e => setEditText(e.target.value)}
+                onKeyDown={e => e.key === "Enter" && handleEditSave()}
+                data-testid="edit-entry-text-input"
+              />
+            </div>
+            <div className="grid gap-2">
+              <label
+                htmlFor="edit-entry-timestamp"
+                className="text-sm font-medium"
+              >
+                Timestamp
+              </label>
+              <Input
+                id="edit-entry-timestamp"
+                value={editTimestamp}
+                onChange={e => setEditTimestamp(e.target.value)}
+                data-testid="edit-entry-timestamp-input"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setEditingEntry(null)}
+              data-testid="cancel-edit-button"
+            >
+              Cancel
+            </Button>
+            <Button
+              onClick={handleEditSave}
+              data-testid="save-edit-button"
+            >
+              Save
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/packages/client/src/context/SessionProvider.tsx
+++ b/packages/client/src/context/SessionProvider.tsx
@@ -115,6 +115,16 @@ export function SessionProvider({
         : s));
   }, [setSessions, activeSessionId]);
 
+  const editEntry = useCallback((index: number, entry: TimerEntry) => {
+    setSessions(prev => prev.map(s =>
+      s.id === activeSessionId
+        ? {
+          ...s,
+          entries: s.entries.map((e, i) => i === index ? entry : e),
+        }
+        : s));
+  }, [setSessions, activeSessionId]);
+
   const deleteEntry = useCallback((index: number) => {
     setSessions(prev => prev.map(s =>
       s.id === activeSessionId
@@ -144,9 +154,10 @@ export function SessionProvider({
     renameSession,
     switchSession,
     addEntry,
+    editEntry,
     deleteEntry,
     deleteEntries,
-  }), [sessions, activeSession, createSession, deleteSession, renameSession, switchSession, addEntry, deleteEntry, deleteEntries]);
+  }), [sessions, activeSession, createSession, deleteSession, renameSession, switchSession, addEntry, editEntry, deleteEntry, deleteEntries]);
 
   return (
     <SessionProviderContext.Provider value={value}>

--- a/packages/client/src/context/SessionProviderContext.ts
+++ b/packages/client/src/context/SessionProviderContext.ts
@@ -19,6 +19,7 @@ export interface SessionProviderState {
   renameSession: (id: string, name: string) => void;
   switchSession: (id: string) => void;
   addEntry: (entry: TimerEntry) => void;
+  editEntry: (index: number, entry: TimerEntry) => void;
   deleteEntry: (index: number) => void;
   deleteEntries: (indices: number[]) => void;
 }
@@ -37,6 +38,7 @@ const initialState: SessionProviderState = {
   renameSession: () => null,
   switchSession: () => null,
   addEntry: () => null,
+  editEntry: () => null,
   deleteEntry: () => null,
   deleteEntries: () => null,
 };

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -42,6 +42,7 @@ export function Index() {
     renameSession,
     deleteSession,
     addEntry,
+    editEntry,
     deleteEntry,
     deleteEntries,
   } = useSession();
@@ -73,6 +74,11 @@ export function Index() {
     setInputValue("");
     setTypingStartMs(null);
   }, [inputValue, addEntry, timestampMode, typingStartMs]);
+
+  const handleEditEntry = useCallback((index: number, entry: { text: string;
+    timestamp: string; }) => {
+    editEntry(index, entry);
+  }, [editEntry]);
 
   const handleDeleteEntry = useCallback((index: number) => {
     deleteEntry(index);
@@ -163,6 +169,7 @@ export function Index() {
         <div className="mt-4 flex w-full justify-center">
           <TimerEntriesTable
             entries={activeSession.entries}
+            onEditEntry={handleEditEntry}
             onDeleteEntry={handleDeleteEntry}
             onDeleteEntries={handleDeleteEntries}
           />


### PR DESCRIPTION
Add an "Edit Entry" button to the row actions popover that opens a
dialog for modifying an entry's text and timestamp. Includes editEntry
in the session context, Storybook stories, and all tests pass.

https://claude.ai/code/session_013W9jrFJEL7jhG3s8eXpK5b