### PR TITLE
Add markdown export dialog for timer entries (#53)

### DIFF
--- a/packages/client/src/components/MarkdownExportDialog.stories.tsx
+++ b/packages/client/src/components/MarkdownExportDialog.stories.tsx
@@ -1,0 +1,83 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, userEvent, within } from "@storybook/test";
+
+import { MarkdownExportDialog } from "./MarkdownExportDialog";
+
+const sampleEntries = [
+  {
+    text: "First task",
+    timestamp: "00:01:23.456",
+  },
+  {
+    text: "Second task",
+    timestamp: "00:05:10.200",
+  },
+  {
+    text: "Third task",
+    timestamp: "00:12:45.789",
+  },
+];
+
+const meta = {
+  component: MarkdownExportDialog,
+  args: {
+    open: true,
+    onOpenChange: fn(),
+    entries: sampleEntries,
+  },
+} satisfies Meta<typeof MarkdownExportDialog>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async () => {
+    const body = within(document.body);
+
+    // Dialog should be visible with title
+    await expect(body.getByText("Export as Markdown")).toBeInTheDocument();
+
+    // Textarea should contain markdown table
+    const textarea = body.getByTestId("markdown-export-textarea") as HTMLTextAreaElement;
+    await expect(textarea).toBeInTheDocument();
+    await expect(textarea.value).toContain("| Text | Timestamp |");
+    await expect(textarea.value).toContain("| First task | 00:01:23.456 |");
+    await expect(textarea.value).toContain("| Second task | 00:05:10.200 |");
+    await expect(textarea.value).toContain("| Third task | 00:12:45.789 |");
+
+    // Textarea should be readonly
+    await expect(textarea).toHaveAttribute("readonly");
+
+    // Copy button should be present
+    await expect(body.getByTestId("copy-markdown-button")).toBeInTheDocument();
+    await expect(body.getByTestId("copy-markdown-button")).toHaveTextContent("Copy to Clipboard");
+  },
+};
+
+export const EmptyEntries: Story = {
+  args: {
+    entries: [],
+  },
+  play: async () => {
+    const body = within(document.body);
+
+    // Textarea should be empty
+    const textarea = body.getByTestId("markdown-export-textarea") as HTMLTextAreaElement;
+    await expect(textarea.value).toBe("");
+  },
+};
+
+export const CloseDialog: Story = {
+  play: async ({
+    args,
+  }) => {
+    const body = within(document.body);
+
+    // Click the close button
+    await userEvent.click(body.getByTestId("dialog-close-button"));
+
+    await expect(args.onOpenChange).toHaveBeenCalledWith(false);
+  },
+};

--- a/packages/client/src/components/MarkdownExportDialog.tsx
+++ b/packages/client/src/components/MarkdownExportDialog.tsx
@@ -1,0 +1,105 @@
+import { useCallback, useRef, useState } from "react";
+
+import { Check, ClipboardCopy } from "lucide-react";
+
+import { Button } from "@/components/Button";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/Dialog";
+
+interface TimerEntry {
+  text: string;
+  timestamp: string;
+}
+
+interface MarkdownExportDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  entries: TimerEntry[];
+}
+
+function entriesToMarkdown(entries: TimerEntry[]): string {
+  if (entries.length === 0) {
+    return "";
+  }
+
+  const header = "| Text | Timestamp |";
+  const separator = "| --- | --- |";
+  const rows = entries.map(entry => `| ${entry.text} | ${entry.timestamp} |`);
+
+  return [header, separator, ...rows].join("\n");
+}
+
+export function MarkdownExportDialog({
+  open,
+  onOpenChange,
+  entries,
+}: MarkdownExportDialogProps) {
+  const [copied, setCopied] = useState(false);
+  const textareaRef = useRef<HTMLTextAreaElement>(null);
+
+  const markdown = entriesToMarkdown(entries);
+
+  const handleCopy = useCallback(async () => {
+    await navigator.clipboard.writeText(markdown);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }, [markdown]);
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(value) => {
+        onOpenChange(value);
+        if (!value) {
+          setCopied(false);
+        }
+      }}
+    >
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Export as Markdown</DialogTitle>
+          <DialogDescription>
+            Copy the markdown below to use your entries elsewhere.
+          </DialogDescription>
+        </DialogHeader>
+        <textarea
+          ref={textareaRef}
+          readOnly
+          value={markdown}
+          className={`
+            h-48 w-full resize-none rounded-md border bg-muted px-3 py-2
+            font-mono text-sm
+            focus:ring-2 focus:ring-ring focus:outline-none
+          `}
+          data-testid="markdown-export-textarea"
+        />
+        <DialogFooter>
+          <Button
+            onClick={handleCopy}
+            data-testid="copy-markdown-button"
+          >
+            {copied
+              ? (
+                <>
+                  <Check className="size-4" />
+                  Copied!
+                </>
+              )
+              : (
+                <>
+                  <ClipboardCopy className="size-4" />
+                  Copy to Clipboard
+                </>
+              )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/client/src/components/TimerEntriesTable.stories.tsx
+++ b/packages/client/src/components/TimerEntriesTable.stories.tsx
@@ -51,6 +51,9 @@ export const Default: Story = {
 
     // No delete button when nothing is selected
     await expect(canvas.queryByTestId("delete-selected-button")).not.toBeInTheDocument();
+
+    // Export as Markdown button should be visible
+    await expect(canvas.getByTestId("export-markdown-button")).toBeInTheDocument();
   },
 };
 
@@ -65,6 +68,9 @@ export const Empty: Story = {
 
     await expect(canvas.getByTestId("timer-entries-empty")).toBeInTheDocument();
     await expect(canvas.queryAllByTestId("timer-entry")).toHaveLength(0);
+
+    // Export button should not be visible when there are no entries
+    await expect(canvas.queryByTestId("export-markdown-button")).not.toBeInTheDocument();
   },
 };
 
@@ -128,6 +134,29 @@ export const Deselection: Story = {
 
     // Delete button should disappear
     await expect(canvas.queryByTestId("delete-selected-button")).not.toBeInTheDocument();
+  },
+};
+
+export const ExportMarkdownDialog: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+
+    // Click the export button
+    await userEvent.click(canvas.getByTestId("export-markdown-button"));
+
+    // Dialog should open with markdown content
+    const body = within(document.body);
+    const textarea = body.getByTestId("markdown-export-textarea") as HTMLTextAreaElement;
+    await expect(textarea).toBeInTheDocument();
+    await expect(textarea.value).toContain("| Text | Timestamp |");
+    await expect(textarea.value).toContain("| First task | 00:01:23.456 |");
+    await expect(textarea.value).toContain("| Second task | 00:05:10.200 |");
+    await expect(textarea.value).toContain("| Third task | 00:12:45.789 |");
+
+    // Copy button should be present
+    await expect(body.getByTestId("copy-markdown-button")).toHaveTextContent("Copy to Clipboard");
   },
 };
 

--- a/packages/client/src/components/TimerEntriesTable.tsx
+++ b/packages/client/src/components/TimerEntriesTable.tsx
@@ -8,7 +8,7 @@ import {
   getSortedRowModel,
   useReactTable,
 } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown, EllipsisVertical, ListChecks, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, ListChecks, Trash2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -22,6 +22,7 @@ import {
 } from "@/components/AlertDialog";
 import { Button } from "@/components/Button";
 import { Checkbox } from "@/components/Checkbox";
+import { MarkdownExportDialog } from "@/components/MarkdownExportDialog";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn } from "@/lib/utils";
@@ -180,6 +181,7 @@ export function TimerEntriesTable({
   const [sorting, setSorting] = useState<SortingState>([]);
   const [rowSelection, setRowSelection] = useState<RowSelectionState>({});
   const [showDeleteDialog, setShowDeleteDialog] = useState(false);
+  const [showMarkdownDialog, setShowMarkdownDialog] = useState(false);
   const [multiselectEnabled, setMultiselectEnabled] = useState(false);
   const isMobile = useIsMobile();
 
@@ -361,6 +363,26 @@ export function TimerEntriesTable({
             )}
         </tbody>
       </table>
+
+      {entries.length > 0 && (
+        <div className="mt-2 flex justify-end">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setShowMarkdownDialog(true)}
+            data-testid="export-markdown-button"
+          >
+            <ClipboardCopy className="size-4" />
+            Export as Markdown
+          </Button>
+        </div>
+      )}
+
+      <MarkdownExportDialog
+        open={showMarkdownDialog}
+        onOpenChange={setShowMarkdownDialog}
+        entries={entries}
+      />
 
       <AlertDialog
         open={showDeleteDialog}


### PR DESCRIPTION
Add an "Export as Markdown" button below the entries table that opens a
dialog with a readonly textarea containing entries formatted as a
markdown table. Includes a copy-to-clipboard button for convenience.

https://claude.ai/code/session_01HjbPa28Sz73UQzFZ6bFxVL