### PR TITLE
Refactor files to have no more than 10 import statements each (#59)

### DIFF
--- a/packages/client/src/components/SettingsPopover.tsx
+++ b/packages/client/src/components/SettingsPopover.tsx
@@ -17,9 +17,7 @@ import {
 import { Button } from "@/components/Button";
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover";
 import { SessionSwitcherDialog } from "@/components/SessionSwitcherDialog";
-import { useSession } from "@/hooks/useSession";
-import { useTheme } from "@/hooks/useTheme";
-import { useTimestampSettings } from "@/hooks/useTimestampSettings";
+import { useSession, useTheme, useTimestampSettings } from "@/hooks";
 import { cn } from "@/lib/utils";
 
 const SettingsPopover: React.FunctionComponent = () => {

--- a/packages/client/src/components/TimerEntriesTable.tsx
+++ b/packages/client/src/components/TimerEntriesTable.tsx
@@ -2,12 +2,7 @@ import type { ColumnDef, Row, RowSelectionState, SortingState, VisibilityState }
 
 import { useEffect, useState } from "react";
 
-import {
-  flexRender,
-  getCoreRowModel,
-  getSortedRowModel,
-  useReactTable,
-} from "@tanstack/react-table";
+import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
 import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, ListChecks, Pencil, Trash2 } from "lucide-react";
 
 import {
@@ -20,8 +15,6 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/AlertDialog";
-import { Button } from "@/components/Button";
-import { Checkbox } from "@/components/Checkbox";
 import {
   Dialog,
   DialogContent,
@@ -30,9 +23,8 @@ import {
   DialogHeader,
   DialogTitle,
 } from "@/components/Dialog";
-import { Input } from "@/components/Input";
 import { MarkdownExportDialog } from "@/components/MarkdownExportDialog";
-import { Popover, PopoverContent, PopoverTrigger } from "@/components/Popover";
+import { Button, Checkbox, Input, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn } from "@/lib/utils";
 

--- a/packages/client/src/components/ui.ts
+++ b/packages/client/src/components/ui.ts
@@ -1,0 +1,5 @@
+export { Button } from "./Button";
+export { Checkbox } from "./Checkbox";
+export { Input } from "./Input";
+export { Popover, PopoverContent, PopoverTrigger } from "./Popover";
+export { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "./Tooltip";

--- a/packages/client/src/hooks/index.ts
+++ b/packages/client/src/hooks/index.ts
@@ -1,0 +1,7 @@
+export { useAppForm } from "./useAppForm";
+export { useFormContext } from "./useFormContext";
+export { useIsMobile } from "./useIsMobile";
+export { useLocalStorage } from "./useLocalStorage";
+export { useSession } from "./useSession";
+export { useTheme } from "./useTheme";
+export { useTimestampSettings } from "./useTimestampSettings";

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -13,14 +13,11 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
 } from "@/components/AlertDialog";
-import { Button } from "@/components/Button";
-import { Input } from "@/components/Input";
 import { SessionName } from "@/components/SessionName";
 import { Timer } from "@/components/Timer";
 import { TimerEntriesTable } from "@/components/TimerEntriesTable";
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/Tooltip";
-import { useSession } from "@/hooks/useSession";
-import { useTimestampSettings } from "@/hooks/useTimestampSettings";
+import { Button, Input, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui";
+import { useSession, useTimestampSettings } from "@/hooks";
 import { formatTime } from "@/utils/formatTime";
 
 export const Route = createFileRoute("/")({

--- a/packages/middleware/src/app.ts
+++ b/packages/middleware/src/app.ts
@@ -6,9 +6,7 @@ import { JsonSchemaToTsProvider } from "@fastify/type-provider-json-schema-to-ts
 import Fastify from "fastify";
 
 import routes from "./routes/routes.ts";
-import { makeEnvOptions } from "./services/env.ts";
-import swaggerOptions from "./services/swaggerOptions.ts";
-import swaggerUiOptions from "./services/swaggerUiOptions.ts";
+import { makeEnvOptions, swaggerOptions, swaggerUiOptions } from "./services/index.ts";
 import { fileURLToPath } from "url";
 import path from "path";
 

--- a/packages/middleware/src/services/index.ts
+++ b/packages/middleware/src/services/index.ts
@@ -1,0 +1,3 @@
+export { makeEnvOptions } from "./env.ts";
+export { default as swaggerOptions } from "./swaggerOptions.ts";
+export { default as swaggerUiOptions } from "./swaggerUiOptions.ts";


### PR DESCRIPTION
Create barrel re-export files for hooks, UI components, and middleware
services to consolidate imports across the 4 files that exceeded the
10-import limit.

https://claude.ai/code/session_01VGqekA9P7ZjM8fEm9tfvZC