### PR TITLE
Add timestamp mode icon column to timer entries table

### DIFF
--- a/packages/client/src/components/MarkdownExportDialog.stories.tsx
+++ b/packages/client/src/components/MarkdownExportDialog.stories.tsx
@@ -8,14 +8,17 @@ const sampleEntries = [
   {
     text: "First task",
     timestamp: "00:01:23.456",
+    mode: "submit" as const,
   },
   {
     text: "Second task",
     timestamp: "00:05:10.200",
+    mode: "typing-start" as const,
   },
   {
     text: "Third task",
     timestamp: "00:12:45.789",
+    mode: "submit" as const,
   },
 ];
 
@@ -42,10 +45,10 @@ export const Default: Story = {
     // Textarea should contain markdown table
     const textarea = body.getByTestId("markdown-export-textarea") as HTMLTextAreaElement;
     await expect(textarea).toBeInTheDocument();
-    await expect(textarea.value).toContain("| Text | Timestamp |");
-    await expect(textarea.value).toContain("| First task | 00:01:23.456 |");
-    await expect(textarea.value).toContain("| Second task | 00:05:10.200 |");
-    await expect(textarea.value).toContain("| Third task | 00:12:45.789 |");
+    await expect(textarea.value).toContain("| Text | Timestamp | Mode |");
+    await expect(textarea.value).toContain("| First task | 00:01:23.456 | Submit |");
+    await expect(textarea.value).toContain("| Second task | 00:05:10.200 | Typing Start |");
+    await expect(textarea.value).toContain("| Third task | 00:12:45.789 | Submit |");
 
     // Textarea should be readonly
     await expect(textarea).toHaveAttribute("readonly");

--- a/packages/client/src/components/MarkdownExportDialog.tsx
+++ b/packages/client/src/components/MarkdownExportDialog.tsx
@@ -15,6 +15,7 @@ import {
 interface TimerEntry {
   text: string;
   timestamp: string;
+  mode?: "submit" | "typing-start";
 }
 
 interface MarkdownExportDialogProps {
@@ -23,9 +24,24 @@ interface MarkdownExportDialogProps {
   entries: TimerEntry[];
 }
 
+function formatMode(mode?: "submit" | "typing-start"): string {
+  if (mode === "typing-start") return "Typing Start";
+  if (mode === "submit") return "Submit";
+  return "";
+}
+
 function entriesToMarkdown(entries: TimerEntry[]): string {
   if (entries.length === 0) {
     return "";
+  }
+
+  const hasMode = entries.some(entry => entry.mode !== undefined);
+
+  if (hasMode) {
+    const header = "| Text | Timestamp | Mode |";
+    const separator = "| --- | --- | --- |";
+    const rows = entries.map(entry => `| ${entry.text} | ${entry.timestamp} | ${formatMode(entry.mode)} |`);
+    return [header, separator, ...rows].join("\n");
   }
 
   const header = "| Text | Timestamp |";

--- a/packages/client/src/components/TimerEntriesTable.stories.tsx
+++ b/packages/client/src/components/TimerEntriesTable.stories.tsx
@@ -8,14 +8,17 @@ const sampleEntries = [
   {
     text: "First task",
     timestamp: "00:01:23.456",
+    mode: "submit" as const,
   },
   {
     text: "Second task",
     timestamp: "00:05:10.200",
+    mode: "typing-start" as const,
   },
   {
     text: "Third task",
     timestamp: "00:12:45.789",
+    mode: "submit" as const,
   },
 ];
 
@@ -151,10 +154,10 @@ export const ExportMarkdownDialog: Story = {
     const body = within(document.body);
     const textarea = body.getByTestId("markdown-export-textarea") as HTMLTextAreaElement;
     await expect(textarea).toBeInTheDocument();
-    await expect(textarea.value).toContain("| Text | Timestamp |");
-    await expect(textarea.value).toContain("| First task | 00:01:23.456 |");
-    await expect(textarea.value).toContain("| Second task | 00:05:10.200 |");
-    await expect(textarea.value).toContain("| Third task | 00:12:45.789 |");
+    await expect(textarea.value).toContain("| Text | Timestamp | Mode |");
+    await expect(textarea.value).toContain("| First task | 00:01:23.456 | Submit |");
+    await expect(textarea.value).toContain("| Second task | 00:05:10.200 | Typing Start |");
+    await expect(textarea.value).toContain("| Third task | 00:12:45.789 | Submit |");
 
     // Copy button should be present
     await expect(body.getByTestId("copy-markdown-button")).toHaveTextContent("Copy to Clipboard");

--- a/packages/client/src/components/TimerEntriesTable.tsx
+++ b/packages/client/src/components/TimerEntriesTable.tsx
@@ -3,7 +3,7 @@ import type { ColumnDef, Row, RowSelectionState, SortingState, VisibilityState }
 import { useEffect, useState } from "react";
 
 import { flexRender, getCoreRowModel, getSortedRowModel, useReactTable } from "@tanstack/react-table";
-import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, ListChecks, Pencil, Trash2 } from "lucide-react";
+import { ArrowDown, ArrowUp, ArrowUpDown, ClipboardCopy, EllipsisVertical, Keyboard, ListChecks, Pencil, Send, Trash2 } from "lucide-react";
 
 import {
   AlertDialog,
@@ -24,13 +24,14 @@ import {
   DialogTitle,
 } from "@/components/Dialog";
 import { MarkdownExportDialog } from "@/components/MarkdownExportDialog";
-import { Button, Checkbox, Input, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
+import { Button, Checkbox, Input, Popover, PopoverContent, PopoverTrigger, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui";
 import { useIsMobile } from "@/hooks/useIsMobile";
 import { cn } from "@/lib/utils";
 
 interface TimerEntry {
   text: string;
   timestamp: string;
+  mode?: "submit" | "typing-start";
 }
 
 interface TimerEntriesTableProps {
@@ -128,6 +129,40 @@ const columns: ColumnDef<TimerEntry>[] = [
             `,
           )}
         />
+      );
+    },
+  },
+  {
+    id: "mode",
+    meta: {
+      className: "w-10",
+    },
+    header: () => null,
+    cell: ({
+      row,
+    }) => {
+      const mode = row.original.mode;
+      if (!mode) return null;
+      return (
+        <TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span
+                className="inline-flex text-muted-foreground"
+                data-testid="entry-mode-icon"
+              >
+                {mode === "typing-start"
+                  ? <Keyboard className="size-4" />
+                  : <Send className="size-4" />}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>
+              {mode === "typing-start"
+                ? "Timestamp captured on typing start"
+                : "Timestamp captured on submit"}
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       );
     },
   },

--- a/packages/client/src/context/SessionProviderContext.ts
+++ b/packages/client/src/context/SessionProviderContext.ts
@@ -1,8 +1,11 @@
+import type { TimestampMode } from "./TimestampSettingsContext.ts";
+
 import { createContext } from "react";
 
 export interface TimerEntry {
   text: string;
   timestamp: string;
+  mode?: TimestampMode;
 }
 
 export interface Session {

--- a/packages/client/src/routes/index.tsx
+++ b/packages/client/src/routes/index.tsx
@@ -67,6 +67,7 @@ export function Index() {
     addEntry({
       text: inputValue.trim(),
       timestamp: formatTime(timestampMs),
+      mode: timestampMode,
     });
     setInputValue("");
     setTypingStartMs(null);


### PR DESCRIPTION
Shows a Keyboard icon for entries captured on typing start and a Send
icon for entries captured on submit, with tooltips explaining each.
The mode is also included in the markdown export when entries have
mode data. Backward-compatible with legacy entries that have no mode.

Closes #61

https://claude.ai/code/session_01Ha992ByV9PBRuCJQ3S1ZZV