### PR TITLE
Replace text-based selectors with test IDs in e2e tests

### DIFF
--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -6,12 +6,8 @@ test.describe("Navigation", () => {
   }) => {
     await page.goto("/");
 
-    await expect(page.getByRole("link", {
-      name: "Home",
-    })).toBeVisible();
-    await expect(page.getByRole("link", {
-      name: "Capture",
-    })).toBeVisible();
+    await expect(page.getByTestId("nav-home-link")).toBeVisible();
+    await expect(page.getByTestId("nav-capture-link")).toBeVisible();
     await expect(page.getByTestId("settings-trigger")).toBeVisible();
   });
 
@@ -19,14 +15,10 @@ test.describe("Navigation", () => {
     page,
   }) => {
     await page.goto("/");
-    await expect(page.getByRole("link", {
-      name: "Home",
-    })).toHaveClass(/active/);
+    await expect(page.getByTestId("nav-home-link")).toHaveClass(/active/);
 
     await page.goto("/capture");
-    await expect(page.getByRole("link", {
-      name: "Capture",
-    })).toHaveClass(/active/);
+    await expect(page.getByTestId("nav-capture-link")).toHaveClass(/active/);
   });
 
   test("navigates between Home and Capture pages", async ({
@@ -35,16 +27,12 @@ test.describe("Navigation", () => {
     await page.goto("/");
 
     // Home -> Capture
-    await page.getByRole("link", {
-      name: "Capture",
-    }).click();
+    await page.getByTestId("nav-capture-link").click();
     await expect(page).toHaveURL(/\/capture/);
     await expect(page.getByTestId("capture-heading")).toBeVisible();
 
     // Capture -> Home
-    await page.getByRole("link", {
-      name: "Home",
-    }).click();
+    await page.getByTestId("nav-home-link").click();
     await expect(page).toHaveURL(/\/$/);
     await expect(page.getByTestId("timer-display")).toBeVisible();
   });

--- a/e2e/sessions.spec.ts
+++ b/e2e/sessions.spec.ts
@@ -67,8 +67,8 @@ test.describe("Sessions", () => {
 
     await page.getByTestId("session-settings-trigger").click();
     await page.getByTestId("delete-session-button").click();
-    await expect(page.getByText("Delete Session?")).toBeVisible();
-    await expect(page.getByText(/Are you sure you want to delete/)).toBeVisible();
+    await expect(page.getByTestId("delete-session-title")).toBeVisible();
+    await expect(page.getByTestId("delete-session-description")).toBeVisible();
     await expect(page.getByTestId("cancel-delete-session")).toBeVisible();
     await expect(page.getByTestId("confirm-delete-session")).toBeVisible();
 
@@ -176,10 +176,8 @@ test.describe("Export as Markdown", () => {
     await page.getByTestId("session-settings-trigger").click();
     await page.getByTestId("export-markdown-button").click();
 
-    await expect(page.getByRole("heading", {
-      name: "Export as Markdown",
-    })).toBeVisible();
-    await expect(page.getByText("Copy the markdown below to use your entries elsewhere.")).toBeVisible();
+    await expect(page.getByTestId("export-markdown-title")).toBeVisible();
+    await expect(page.getByTestId("export-markdown-description")).toBeVisible();
 
     const textarea = page.getByTestId("markdown-export-textarea");
     await expect(textarea).toBeVisible();
@@ -227,10 +225,8 @@ test.describe("Session switcher dialog", () => {
     await expect(page.getByTestId("switch-session-trigger")).toContainText("Switch Session");
 
     await page.getByTestId("switch-session-trigger").click();
-    await expect(page.getByRole("heading", {
-      name: "Switch Session",
-    })).toBeVisible();
-    await expect(page.getByText("Select a session or create a new one.")).toBeVisible();
+    await expect(page.getByTestId("switch-session-title")).toBeVisible();
+    await expect(page.getByTestId("switch-session-description")).toBeVisible();
     await expect(page.getByTestId("session-list-item")).toHaveCount(1);
     await expect(page.getByTestId("new-session-button")).toBeVisible();
 

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -11,8 +11,8 @@ test.describe("Settings and dark mode", () => {
     page,
   }) => {
     await page.getByTestId("settings-trigger").click();
-    await expect(page.getByText("Settings").first()).toBeVisible();
-    await expect(page.getByText("Dark Mode")).toBeVisible();
+    await expect(page.getByTestId("settings-heading")).toBeVisible();
+    await expect(page.getByTestId("dark-mode-label")).toBeVisible();
 
     const toggle = page.getByTestId("dark-mode-toggle");
     await expect(toggle).toHaveRole("switch");

--- a/packages/client/src/components/SessionSettingsMenu.tsx
+++ b/packages/client/src/components/SessionSettingsMenu.tsx
@@ -102,8 +102,8 @@ export function SessionSettingsMenu({
       >
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>Delete Session?</AlertDialogTitle>
-            <AlertDialogDescription>
+            <AlertDialogTitle data-testid="delete-session-title">Delete Session?</AlertDialogTitle>
+            <AlertDialogDescription data-testid="delete-session-description">
               Are you sure you want to delete &quot;
               {sessionName}
               &quot;? All entries in this session will be permanently removed. This action cannot be undone.

--- a/packages/client/src/components/SettingsPopover.tsx
+++ b/packages/client/src/components/SettingsPopover.tsx
@@ -53,9 +53,19 @@ const SettingsPopover: React.FunctionComponent = () => {
           className="w-64"
         >
           <div className="space-y-4">
-            <h4 className="text-sm leading-none font-medium">Settings</h4>
+            <h4
+              className="text-sm leading-none font-medium"
+              data-testid="settings-heading"
+            >
+              Settings
+            </h4>
             <div className="flex items-center justify-between">
-              <span className="text-sm">Dark Mode</span>
+              <span
+                className="text-sm"
+                data-testid="dark-mode-label"
+              >
+                Dark Mode
+              </span>
               <SwitchPrimitive.Root
                 checked={isDark}
                 onCheckedChange={(checked) => { setTheme(checked ? "dark" : "light"); }}

--- a/packages/client/src/components/dialogs/MarkdownExportDialog.tsx
+++ b/packages/client/src/components/dialogs/MarkdownExportDialog.tsx
@@ -79,8 +79,8 @@ export function MarkdownExportDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Export as Markdown</DialogTitle>
-          <DialogDescription>
+          <DialogTitle data-testid="export-markdown-title">Export as Markdown</DialogTitle>
+          <DialogDescription data-testid="export-markdown-description">
             Copy the markdown below to use your entries elsewhere.
           </DialogDescription>
         </DialogHeader>

--- a/packages/client/src/components/dialogs/SessionSwitcherDialog.tsx
+++ b/packages/client/src/components/dialogs/SessionSwitcherDialog.tsx
@@ -69,8 +69,8 @@ export function SessionSwitcherDialog({
     >
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Switch Session</DialogTitle>
-          <DialogDescription>
+          <DialogTitle data-testid="switch-session-title">Switch Session</DialogTitle>
+          <DialogDescription data-testid="switch-session-description">
             Select a session or create a new one.
           </DialogDescription>
         </DialogHeader>

--- a/packages/client/src/routes/__root.tsx
+++ b/packages/client/src/routes/__root.tsx
@@ -12,6 +12,7 @@ const RootComponent: React.FunctionComponent = () => {
           <Link
             to="/"
             className="[&.active]:font-bold"
+            data-testid="nav-home-link"
           >
             Home
           </Link>
@@ -19,6 +20,7 @@ const RootComponent: React.FunctionComponent = () => {
           <Link
             to="/capture"
             className="[&.active]:font-bold"
+            data-testid="nav-capture-link"
           >
             Capture
           </Link>


### PR DESCRIPTION
## Summary
This PR improves the reliability and maintainability of end-to-end tests by replacing fragile text-based selectors with dedicated `data-testid` attributes. This makes tests more resilient to UI text changes and follows testing best practices.

## Key Changes
- **Navigation tests**: Replaced `getByRole("link", { name: "..." })` selectors with `getByTestId()` for Home and Capture links
- **Settings tests**: Added `data-testid` attributes to Settings heading and Dark Mode label, updated tests to use them
- **Dialog tests**: Added `data-testid` attributes to dialog titles and descriptions:
  - Delete Session dialog: `delete-session-title` and `delete-session-description`
  - Export as Markdown dialog: `export-markdown-title` and `export-markdown-description`
  - Session Switcher dialog: `switch-session-title` and `switch-session-description`
- **Component updates**: Added `data-testid` props to relevant UI elements in:
  - `SettingsPopover.tsx`
  - `SessionSettingsMenu.tsx`
  - `MarkdownExportDialog.tsx`
  - `SessionSwitcherDialog.tsx`
  - `__root.tsx` (navigation links)

## Implementation Details
- All `data-testid` attributes follow a consistent naming convention (kebab-case)
- Test IDs are semantic and describe the element's purpose rather than its implementation
- No functional changes to the application; this is purely a testing infrastructure improvement
- Tests are now decoupled from UI text content, making them more maintainable when copy changes occur

https://claude.ai/code/session_01VEdBktw96oBVMfBUK5ozHJ