### PR TITLE
Refactor quiz settings into popover menu component

### DIFF
--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.stories.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.stories.tsx
@@ -19,7 +19,7 @@ export const Default: Story = {
   }) => {
     const canvas = within(canvasElement);
     await expect(canvas.getByTestId("giving-receiving-quiz")).toBeInTheDocument();
-    await expect(canvas.getByTestId("quiz-mode-selector")).toBeInTheDocument();
+    await expect(canvas.getByTestId("quiz-settings-trigger")).toBeInTheDocument();
     await expect(canvas.getByTestId("quiz-score")).toHaveTextContent("Score: 0 / 0");
   },
 };

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.tsx
@@ -1,41 +1,12 @@
-import type { Sentence } from "../-utils/types";
+import type { Mode, Sentence } from "../-utils/types";
 
 import { useCallback, useMemo, useState } from "react";
 
 import { FillInBlank } from "./FillInBlank";
 import { GrammarPointGrid } from "./GrammarPointGrid";
+import { QuizSettingsMenu } from "./QuizSettingsMenu";
 import { RevealTranslation } from "./RevealTranslation";
 import { SENTENCES } from "../-utils/sentences";
-
-import { Button } from "@/components/ui";
-import { cn } from "@/lib/utils";
-
-type Mode = "mixed" | "fill-in-blank" | "reveal-translation" | "grammar-point-grid";
-
-const MODES: { mode: Mode;
-  label: string;
-  testId: string; }[] = [
-  {
-    mode: "mixed",
-    label: "Mixed",
-    testId: "mode-mixed",
-  },
-  {
-    mode: "fill-in-blank",
-    label: "Fill in the blank",
-    testId: "mode-fill-in-blank",
-  },
-  {
-    mode: "reveal-translation",
-    label: "Reveal translation",
-    testId: "mode-reveal-translation",
-  },
-  {
-    mode: "grammar-point-grid",
-    label: "Pick the grammar point",
-    testId: "mode-grammar-point-grid",
-  },
-];
 
 function pickRandom<T>(items: readonly T[]): T {
   const item = items[Math.floor(Math.random() * items.length)];
@@ -114,46 +85,31 @@ export function GivingReceivingQuiz() {
       className="flex flex-col gap-6"
       data-testid="giving-receiving-quiz"
     >
-      <div className="flex flex-col gap-2">
-        <p className="text-sm font-medium">Question type</p>
+      <div className="flex items-center justify-between gap-2">
         <div
-          className="flex flex-wrap gap-2"
-          data-testid="quiz-mode-selector"
+          className="text-sm text-muted-foreground"
+          data-testid="quiz-score"
         >
-          {MODES.map(m => (
-            <Button
-              key={m.mode}
-              variant={mode === m.mode ? "default" : "outline"}
-              size="sm"
-              className={cn(mode === m.mode && "ring-2 ring-ring")}
-              onClick={() => { handleSetMode(m.mode); }}
-              data-testid={m.testId}
-            >
-              {m.label}
-            </Button>
-          ))}
+          Score:
+          {" "}
+          {score.correct}
+          {" "}
+          /
+          {" "}
+          {score.total}
+          {accuracy !== null && (
+            <>
+              {" "}
+              (
+              {accuracy}
+              %)
+            </>
+          )}
         </div>
-      </div>
-
-      <div
-        className="text-sm text-muted-foreground"
-        data-testid="quiz-score"
-      >
-        Score:
-        {" "}
-        {score.correct}
-        {" "}
-        /
-        {" "}
-        {score.total}
-        {accuracy !== null && (
-          <>
-            {" "}
-            (
-            {accuracy}
-            %)
-          </>
-        )}
+        <QuizSettingsMenu
+          mode={mode}
+          onModeChange={handleSetMode}
+        />
       </div>
 
       <div

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.stories.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.stories.tsx
@@ -1,0 +1,54 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+
+import { expect, fn, screen, userEvent, within } from "@storybook/test";
+
+import { QuizSettingsMenu } from "./QuizSettingsMenu";
+
+const meta = {
+  title: "Quizzes/Giving and Receiving/QuizSettingsMenu",
+  component: QuizSettingsMenu,
+  args: {
+    mode: "mixed",
+    onModeChange: fn(),
+  },
+} satisfies Meta<typeof QuizSettingsMenu>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByTestId("quiz-settings-trigger")).toBeInTheDocument();
+    await expect(screen.queryByTestId("quiz-mode-selector")).not.toBeInTheDocument();
+  },
+};
+
+export const OpensPopover: Story = {
+  play: async ({
+    canvasElement,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("quiz-settings-trigger"));
+    const selector = await screen.findByTestId("quiz-mode-selector");
+    await expect(selector).toBeInTheDocument();
+    await expect(screen.getByTestId("mode-mixed")).toBeInTheDocument();
+    await expect(screen.getByTestId("mode-fill-in-blank")).toBeInTheDocument();
+    await expect(screen.getByTestId("mode-reveal-translation")).toBeInTheDocument();
+    await expect(screen.getByTestId("mode-grammar-point-grid")).toBeInTheDocument();
+  },
+};
+
+export const SelectingModeFiresCallback: Story = {
+  play: async ({
+    canvasElement, args,
+  }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByTestId("quiz-settings-trigger"));
+    await userEvent.click(await screen.findByTestId("mode-fill-in-blank"));
+    await expect(args.onModeChange).toHaveBeenCalledWith("fill-in-blank");
+  },
+};

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.tsx
@@ -2,10 +2,10 @@ import type { Mode } from "../-utils/types";
 
 import { Settings } from "lucide-react";
 
+import { MODES } from "../-utils/types";
+
 import { Button, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
 import { cn } from "@/lib/utils";
-
-import { MODES } from "../-utils/types";
 
 interface QuizSettingsMenuProps {
   mode: Mode;

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/QuizSettingsMenu.tsx
@@ -1,0 +1,63 @@
+import type { Mode } from "../-utils/types";
+
+import { Settings } from "lucide-react";
+
+import { Button, Popover, PopoverContent, PopoverTrigger } from "@/components/ui";
+import { cn } from "@/lib/utils";
+
+import { MODES } from "../-utils/types";
+
+interface QuizSettingsMenuProps {
+  mode: Mode;
+  onModeChange: (mode: Mode) => void;
+}
+
+export function QuizSettingsMenu({
+  mode,
+  onModeChange,
+}: QuizSettingsMenuProps) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          data-testid="quiz-settings-trigger"
+        >
+          <Settings className="size-5" />
+          <span className="sr-only">Quiz settings</span>
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="end"
+        className="w-64"
+      >
+        <div className="space-y-3">
+          <h4
+            className="text-sm leading-none font-medium"
+            data-testid="quiz-settings-heading"
+          >
+            Question type
+          </h4>
+          <div
+            className="flex flex-wrap gap-2"
+            data-testid="quiz-mode-selector"
+          >
+            {MODES.map(m => (
+              <Button
+                key={m.mode}
+                variant={mode === m.mode ? "default" : "outline"}
+                size="sm"
+                className={cn(mode === m.mode && "ring-2 ring-ring")}
+                onClick={() => { onModeChange(m.mode); }}
+                data-testid={m.testId}
+              >
+                {m.label}
+              </Button>
+            ))}
+          </div>
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-utils/types.ts
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-utils/types.ts
@@ -40,3 +40,30 @@ export interface Sentence {
 
   note?: string;
 }
+
+export type Mode = "mixed" | "fill-in-blank" | "reveal-translation" | "grammar-point-grid";
+
+export const MODES: { mode: Mode;
+  label: string;
+  testId: string; }[] = [
+  {
+    mode: "mixed",
+    label: "Mixed",
+    testId: "mode-mixed",
+  },
+  {
+    mode: "fill-in-blank",
+    label: "Fill in the blank",
+    testId: "mode-fill-in-blank",
+  },
+  {
+    mode: "reveal-translation",
+    label: "Reveal translation",
+    testId: "mode-reveal-translation",
+  },
+  {
+    mode: "grammar-point-grid",
+    label: "Pick the grammar point",
+    testId: "mode-grammar-point-grid",
+  },
+];


### PR DESCRIPTION
## Summary

Extracted the quiz mode selector from the main quiz component into a dedicated `QuizSettingsMenu` component that displays as a popover menu. This improves the UI layout by moving the mode selection controls into a settings icon, reducing visual clutter on the main quiz interface.

## Changes

- Created new `QuizSettingsMenu` component that wraps mode selection in a popover triggered by a settings icon
- Moved `Mode` type and `MODES` constant to `types.ts` for better organization and reusability
- Updated `GivingReceivingQuiz` to use the new settings menu component
- Refactored the header layout to display score and settings menu side-by-side
- Added Storybook stories for the new `QuizSettingsMenu` component with interaction tests

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)
- [ ] Storybook stories render correctly

## Notes

The refactoring maintains all existing functionality while improving the UI organization. The mode selector is now accessible via a settings icon in the top-right of the quiz interface, keeping the main quiz area cleaner.

https://claude.ai/code/session_016LnqrhStXsFPLH7ee1fzby