### PR TITLE
Improve romaji input handling and grammar point quiz UX

### DIFF
--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/FillInBlank.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/FillInBlank.tsx
@@ -2,11 +2,11 @@ import type { Sentence } from "../-utils/types";
 
 import { useCallback, useMemo, useState } from "react";
 
+import { Button, Input } from "@/components/ui";
+import { romajiToHiragana, romajiToHiraganaInProgress } from "@/utils/romajiToHiragana";
+
 import { getWrongAnswerFeedback, GRAMMAR_POINT_SUMMARIES } from "../-utils/feedback";
 import { GRAMMAR_POINT_LABELS } from "../-utils/types";
-
-import { Button, Input } from "@/components/ui";
-import { romajiToHiragana } from "@/utils/romajiToHiragana";
 
 interface FillInBlankProps {
 
@@ -32,26 +32,26 @@ function guessGrammarPoint(answer: string): Sentence["grammarPoint"] | null {
 export function FillInBlank({
   sentence, onNext, onResult,
 }: FillInBlankProps) {
-  const [raw, setRaw] = useState("");
+  const [value, setValue] = useState("");
   const [status, setStatus] = useState<Status>("input");
 
-  const hiragana = useMemo(() => romajiToHiragana(raw), [raw]);
+  const finalHiragana = useMemo(() => romajiToHiragana(value), [value]);
 
   const handleSubmit = useCallback(() => {
     if (status !== "input") return;
-    if (!hiragana) return;
-    const isCorrect = sentence.acceptableAnswers.includes(hiragana);
+    if (!finalHiragana) return;
+    const isCorrect = sentence.acceptableAnswers.includes(finalHiragana);
     setStatus(isCorrect ? "correct" : "incorrect");
     onResult?.(isCorrect);
-  }, [hiragana, sentence.acceptableAnswers, status, onResult]);
+  }, [finalHiragana, sentence.acceptableAnswers, status, onResult]);
 
   const handleNext = useCallback(() => {
-    setRaw("");
+    setValue("");
     setStatus("input");
     onNext();
   }, [onNext]);
 
-  const guessed = guessGrammarPoint(hiragana);
+  const guessed = guessGrammarPoint(finalHiragana);
   const failureNote
     = status === "incorrect" && guessed && guessed !== sentence.grammarPoint
       ? getWrongAnswerFeedback(guessed, sentence.grammarPoint)
@@ -94,7 +94,7 @@ export function FillInBlank({
           `}
           data-testid="fill-in-blank-display"
         >
-          {hiragana || " "}
+          {value || " "}
         </span>
         {blankParts[1]}
       </p>
@@ -108,9 +108,9 @@ export function FillInBlank({
         <div className="flex gap-2">
           <Input
             id="fib-input"
-            value={raw}
+            value={value}
             disabled={status !== "input"}
-            onChange={(e) => { setRaw(e.target.value); }}
+            onChange={(e) => { setValue(romajiToHiraganaInProgress(e.target.value)); }}
             onKeyDown={(e) => { if (e.key === "Enter") handleSubmit(); }}
             placeholder="e.g. ageta, kuremashita, moratta..."
             data-testid="fill-in-blank-input"
@@ -122,7 +122,7 @@ export function FillInBlank({
             ? (
               <Button
                 onClick={handleSubmit}
-                disabled={!hiragana}
+                disabled={!finalHiragana}
                 data-testid="fill-in-blank-submit"
               >
                 Check

--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/GrammarPointGrid.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/GrammarPointGrid.tsx
@@ -2,11 +2,11 @@ import type { GrammarPoint, Sentence } from "../-utils/types";
 
 import { useCallback, useMemo, useState } from "react";
 
-import { getWrongAnswerFeedback, GRAMMAR_POINT_SUMMARIES } from "../-utils/feedback";
-import { GRAMMAR_POINT_LABELS, GRAMMAR_POINTS } from "../-utils/types";
-
 import { Button } from "@/components/ui";
 import { cn } from "@/lib/utils";
+
+import { getWrongAnswerFeedback, GRAMMAR_POINT_SUMMARIES } from "../-utils/feedback";
+import { GRAMMAR_POINT_LABELS, GRAMMAR_POINTS } from "../-utils/types";
 
 interface GrammarPointGridProps {
 
@@ -84,10 +84,16 @@ export function GrammarPointGrid({
         className="text-sm font-medium text-muted-foreground"
         data-testid="grammar-point-grid-prompt"
       >
-        Which grammar point fits this English sentence?
+        Which grammar point fills the blank?
       </p>
       <p
         className="text-xl leading-relaxed"
+        data-testid="grammar-point-grid-japanese"
+      >
+        {sentence.japaneseBlank}
+      </p>
+      <p
+        className="text-base leading-relaxed text-muted-foreground"
         data-testid="grammar-point-grid-english"
       >
         {sentence.english}

--- a/packages/client/src/routes/quizzes/giving-and-receiving/CLAUDE.md
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/CLAUDE.md
@@ -46,7 +46,7 @@ pnpm --filter=@cc-experiments/client run routeTree
 
 1. **Fill-in-the-blank**: the English translation is shown for context. The blank covers only the auxiliary giving/receiving verb (the て stays attached to the main verb in て-form sentences). User input is romaji that gets converted to hiragana live.
 2. **Reveal-translation**: the Japanese is shown and the user clicks to reveal the English. The user self-rates how well they understood — there is no automated grading. Used as flash-card style review.
-3. **Pick the grammar point**: only the English translation is shown. The user picks one of the six grammar points from a 2×3 grid; placement is shuffled per round via a deterministic seed.
+3. **Pick the grammar point**: the Japanese sentence is shown with the grammar point replaced by a blank, with the English translation underneath as context. The user picks one of the six grammar points from a 2×3 grid; placement is shuffled per round via a deterministic seed.
 
 **Never quiz the user on the English translation of a sentence.** The English is always provided when shown — it is context, not a prompt.
 

--- a/packages/client/src/utils/romajiToHiragana.test.ts
+++ b/packages/client/src/utils/romajiToHiragana.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { romajiToHiragana } from "./romajiToHiragana";
+import { romajiToHiragana, romajiToHiraganaInProgress } from "./romajiToHiragana";
 
 describe("romajiToHiragana", () => {
   it("converts basic vowels", () => {
@@ -66,5 +66,29 @@ describe("romajiToHiragana", () => {
 
   it("preserves unknown characters", () => {
     expect(romajiToHiragana("a?")).toBe("あ?");
+  });
+});
+
+describe("romajiToHiraganaInProgress", () => {
+  it("preserves trailing single n so 'no' can still become の", () => {
+    expect(romajiToHiraganaInProgress("n")).toBe("n");
+    expect(romajiToHiraganaInProgress("ho")).toBe("ほ");
+    expect(romajiToHiraganaInProgress("hon")).toBe("ほn");
+  });
+
+  it("converts trailing nn to ん", () => {
+    expect(romajiToHiraganaInProgress("konn")).toBe("こん");
+  });
+
+  it("passes pure hiragana through unchanged", () => {
+    expect(romajiToHiraganaInProgress("あげた")).toBe("あげた");
+  });
+
+  it("converts mixed input on each keystroke", () => {
+    expect(romajiToHiraganaInProgress("a")).toBe("あ");
+    expect(romajiToHiraganaInProgress("あg")).toBe("あg");
+    expect(romajiToHiraganaInProgress("あge")).toBe("あげ");
+    expect(romajiToHiraganaInProgress("あげt")).toBe("あげt");
+    expect(romajiToHiraganaInProgress("あげta")).toBe("あげた");
   });
 });

--- a/packages/client/src/utils/romajiToHiragana.ts
+++ b/packages/client/src/utils/romajiToHiragana.ts
@@ -122,6 +122,17 @@ const KANA_MAP: Record<string, string> = {
 
 const VOWELS = new Set(["a", "i", "u", "e", "o"]);
 
+// Like romajiToHiragana, but preserves a trailing single "n" so a user mid-typing
+// "no" doesn't see ん committed before the "o" arrives. Trailing "nn" still
+// converts to ん since it's unambiguous.
+export function romajiToHiraganaInProgress(input: string): string {
+  const lower = input.toLowerCase();
+  if (lower.endsWith("n") && !lower.endsWith("nn")) {
+    return romajiToHiragana(input.slice(0, -1)) + input.slice(-1);
+  }
+  return romajiToHiragana(input);
+}
+
 export function romajiToHiragana(input: string): string {
   const normalized = input.toLowerCase().replace(/-/g, "");
   let result = "";


### PR DESCRIPTION
## Summary

This PR enhances the romaji-to-hiragana conversion for live input and improves the grammar point selection quiz interface. The main improvements are:

1. **Live romaji conversion**: Implements `romajiToHiraganaInProgress()` to handle mid-typing scenarios better, preserving trailing single "n" so users can still type "no" → "の" without premature conversion to "ん"
2. **Grammar point quiz clarity**: Shows the Japanese sentence with a blank alongside the English translation, making the quiz more contextual and easier to understand
3. **Code organization**: Reorganizes imports to follow a consistent pattern (UI components first, then utilities, then local modules)

## Changes

- **FillInBlank.tsx**: 
  - Renamed state variables (`raw` → `value`, `hiragana` → `finalHiragana`) for clarity
  - Updated input onChange to use `romajiToHiraganaInProgress()` for better live conversion
  - Display the raw input value in the preview instead of the converted hiragana
  - Reorganized imports

- **romajiToHiragana.ts**:
  - Added `romajiToHiraganaInProgress()` function that preserves trailing single "n" to allow mid-typing conversions (e.g., "hon" → "ほn" instead of "ほん")
  - Trailing "nn" still converts to "ん" since it's unambiguous

- **romajiToHiragana.test.ts**:
  - Added comprehensive test suite for `romajiToHiraganaInProgress()` covering edge cases like trailing n, mixed input, and pure hiragana passthrough

- **GrammarPointGrid.tsx**:
  - Updated prompt text from "Which grammar point fits this English sentence?" to "Which grammar point fills the blank?"
  - Added display of `sentence.japaneseBlank` to show the Japanese sentence with the blank
  - Reorganized imports for consistency

- **CLAUDE.md**:
  - Updated documentation to reflect that the grammar point quiz now shows the Japanese sentence with blank and English translation

## Testing

- Added unit tests for `romajiToHiraganaInProgress()` covering trailing n preservation, nn conversion, mixed input, and pure hiragana passthrough
- Existing tests continue to pass
- Changes are backward compatible with existing quiz functionality

## Notes

The `romajiToHiraganaInProgress()` function is specifically designed for real-time input handling where intermediate states matter. The trailing "n" preservation allows users to naturally type Japanese words like "no" (の) without seeing the "n" prematurely convert to ん before the "o" arrives.

https://claude.ai/code/session_018mufEupmQyQike3n7rYw3L