### PR TITLE
Track quiz session state to enable sentence cycling

### DIFF
--- a/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.tsx
+++ b/packages/client/src/routes/quizzes/giving-and-receiving/-components/GivingReceivingQuiz.tsx
@@ -33,14 +33,25 @@ interface QuizState {
   shuffleSeed: number;
 }
 
-function newRound(mode: Mode, exclude?: string): QuizState {
-  const pool = exclude
-    ? SENTENCES.filter(s => s.id !== exclude)
-    : SENTENCES;
+interface QuizSession {
+  round: QuizState;
+  seen: ReadonlySet<string>;
+}
+
+function nextSession(mode: Mode, seen: ReadonlySet<string>): QuizSession {
+  const remaining = SENTENCES.filter(s => !seen.has(s.id));
+  const exhausted = remaining.length === 0;
+  const pool = exhausted ? SENTENCES : remaining;
+  const sentence = pickRandom(pool);
+  const nextSeen = exhausted ? new Set<string>() : new Set(seen);
+  nextSeen.add(sentence.id);
   return {
-    sentence: pickRandom(pool),
-    mode: modeForRound(mode),
-    shuffleSeed: Math.floor(Math.random() * 1_000_000),
+    round: {
+      sentence,
+      mode: modeForRound(mode),
+      shuffleSeed: Math.floor(Math.random() * 1_000_000),
+    },
+    seen: nextSeen,
   };
 }
 
@@ -52,7 +63,8 @@ export function GivingReceivingQuiz({
   onStart,
 }: GivingReceivingQuizProps = {}) {
   const [mode, setMode] = useState<Mode>("mixed");
-  const [round, setRound] = useState<QuizState>(() => newRound("mixed"));
+  const [session, setSession] = useState<QuizSession>(() =>
+    nextSession("mixed", new Set()));
   const [score, setScore] = useState({
     correct: 0,
     total: 0,
@@ -66,7 +78,7 @@ export function GivingReceivingQuiz({
   }, [onStart]);
 
   const handleNext = useCallback(() => {
-    setRound(prev => newRound(mode, prev.sentence.id));
+    setSession(prev => nextSession(mode, prev.seen));
   }, [mode]);
 
   const handleResult = useCallback((wasCorrect: boolean) => {
@@ -87,7 +99,7 @@ export function GivingReceivingQuiz({
 
   const handleSetMode = useCallback((newMode: Mode) => {
     setMode(newMode);
-    setRound(newRound(newMode));
+    setSession(prev => nextSession(newMode, prev.seen));
   }, []);
 
   const accuracy = useMemo(() => {
@@ -128,30 +140,30 @@ export function GivingReceivingQuiz({
       </div>
 
       <div
-        key={round.sentence.id + round.mode}
+        key={session.round.sentence.id + session.round.mode}
         className="rounded-lg border p-4"
-        data-testid={`quiz-round-${round.mode}`}
+        data-testid={`quiz-round-${session.round.mode}`}
       >
-        {round.mode === "fill-in-blank" && (
+        {session.round.mode === "fill-in-blank" && (
           <FillInBlank
-            sentence={round.sentence}
+            sentence={session.round.sentence}
             onNext={handleNext}
             onResult={handleResult}
           />
         )}
-        {round.mode === "reveal-translation" && (
+        {session.round.mode === "reveal-translation" && (
           <RevealTranslation
-            sentence={round.sentence}
+            sentence={session.round.sentence}
             onNext={handleNext}
             onResult={handleRevealRated}
           />
         )}
-        {round.mode === "grammar-point-grid" && (
+        {session.round.mode === "grammar-point-grid" && (
           <GrammarPointGrid
-            sentence={round.sentence}
+            sentence={session.round.sentence}
             onNext={handleNext}
             onResult={handleResult}
-            shuffleSeed={round.shuffleSeed}
+            shuffleSeed={session.round.shuffleSeed}
           />
         )}
       </div>


### PR DESCRIPTION
## Summary

Refactor the quiz state management to track which sentences have been seen during a session. This enables the quiz to cycle through all available sentences before repeating, improving the user experience by ensuring variety in questions.

## Changes

- Introduce `QuizSession` interface to encapsulate both the current round state and a set of seen sentence IDs
- Replace `newRound()` function with `nextSession()` that:
  - Filters out previously seen sentences from the pool
  - Automatically resets the seen set when all sentences have been exhausted
  - Returns both the next round and updated session state
- Update all state management and component logic to work with `session` instead of `round`
- Update all template references to access `session.round` instead of `round`

## Testing

- [ ] Unit tests pass (`pnpm test`)
- [ ] Lint passes (`pnpm lint`)
- [ ] Build succeeds (`pnpm build`)
- [ ] E2E tests pass (`pnpm e2e`)

## Notes

This change maintains backward compatibility with the component's public API while improving the internal state management. The quiz will now cycle through all available sentences before repeating any, providing better variety during a session.

https://claude.ai/code/session_013dS8YZvSniPYDggnKgkHki