### PR TITLE
Add GitHub Pages SPA routing support with 404 redirect

### DIFF
--- a/packages/client/index.html
+++ b/packages/client/index.html
@@ -8,6 +8,20 @@
             rel="stylesheet"
             href="./src/index.css"
             />
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // https://github.com/rafgraph/spa-github-pages
+            // Decodes the path that 404.html encoded into the query string
+            // so the router sees the original URL on refresh / direct links.
+            (function (l) {
+                if (l.search[1] === "/") {
+                    var decoded = l.search.slice(1).split("&").map(function (s) {
+                        return s.replace(/~and~/g, "&");
+                    }).join("?");
+                    window.history.replaceState(null, null, l.pathname.slice(0, -1) + decoded + l.hash);
+                }
+            }(window.location));
+        </script>
     </head>
 <body>
 <div id="root"></div>

--- a/packages/client/public/404.html
+++ b/packages/client/public/404.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>cc-experiments</title>
+        <script type="text/javascript">
+            // Single Page Apps for GitHub Pages
+            // https://github.com/rafgraph/spa-github-pages
+            // MIT License
+            // Redirects 404s to index.html while preserving the requested path
+            // so the SPA router can render the correct route after a refresh
+            // or direct link. `pathSegmentsToKeep` matches the GitHub Pages
+            // base path segment count (here: "/claude-code-experiment/").
+            var pathSegmentsToKeep = 1;
+
+            var l = window.location;
+            l.replace(
+                l.protocol + "//" + l.hostname + (l.port ? ":" + l.port : "") +
+                l.pathname.split("/").slice(0, 1 + pathSegmentsToKeep).join("/") + "/?/" +
+                l.pathname.slice(1).split("/").slice(pathSegmentsToKeep).join("/").replace(/&/g, "~and~") +
+                (l.search ? "&" + l.search.slice(1).replace(/&/g, "~and~") : "") +
+                l.hash,
+            );
+        </script>
+    </head>
+    <body></body>
+</html>


### PR DESCRIPTION
## Summary

Adds GitHub Pages Single Page App (SPA) routing support to enable proper client-side routing when users refresh or directly link to nested routes. This implements the spa-github-pages pattern to handle 404s and preserve the requested path.

## Changes

- Added `packages/client/public/404.html` with redirect logic that encodes the requested path into a query string when a 404 occurs
- Modified `packages/client/index.html` to decode the path from the query string and restore it in the browser history on page load

These changes allow the SPA router to correctly render the intended route even when users refresh the page or access a nested route directly, which would otherwise result in a 404 on GitHub Pages.

## Testing

- [ ] Build succeeds (`pnpm build`)
- [ ] Verify routing works correctly on GitHub Pages deployment with direct links and page refreshes

## Notes

This implementation follows the [spa-github-pages](https://github.com/rafgraph/spa-github-pages) pattern (MIT License) and is configured for a base path of `/claude-code-experiment/` as indicated by `pathSegmentsToKeep = 1`.

https://claude.ai/code/session_01PzJcwzARPNBSWcfotcFExo